### PR TITLE
Remove jq dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ TCPDUMP_VERSION=4.9.2
 STATIC_TCPDUMP_NAME=static-tcpdump
 NEW_PLUGIN_SYSTEM_MINIMUM_KUBECTL_VERSION=12
 UNAME := $(shell uname)
-KUBECTL_MINOR_VERSION=$(shell kubectl version --client=true --short=true -o json | jq .clientVersion.minor)
+KUBECTL_MINOR_VERSION=$(shell kubectl version --client=true --short=true -o yaml | grep minor | grep -Eow "[0-9]+")
 IS_NEW_PLUGIN_SUBSYSTEM := $(shell [ $(KUBECTL_MINOR_VERSION) -ge $(NEW_PLUGIN_SYSTEM_MINIMUM_KUBECTL_VERSION) ] && echo true)
 
 ifeq ($(IS_NEW_PLUGIN_SUBSYSTEM),true)

--- a/README.md
+++ b/README.md
@@ -37,8 +37,7 @@ For manual installation, download the latest release package, unzip it and use t
 
 Requirements:
 1. libpcap-dev: for tcpdump compilation (Ubuntu: sudo apt-get install libpcap-dev)
-2. jq: for parsing kubectl version
-3. go 1.11 or newer
+2. go 1.11 or newer
 
 Compiling:
  


### PR DESCRIPTION
We can build it without `jq` dependency if we rely on `grep`.