### PR TITLE
Privileged Pod creation timeout option. Resolves #76.

### DIFF
--- a/kube/kubernetes_api_service.go
+++ b/kube/kubernetes_api_service.go
@@ -21,7 +21,7 @@ type KubernetesApiService interface {
 
 	DeletePod(podName string) error
 
-	CreatePrivilegedPod(nodeName string, image string) (*corev1.Pod, error)
+	CreatePrivilegedPod(nodeName string, image string, timeout time.Duration) (*corev1.Pod, error)
 
 	UploadFile(localPath string, remotePath string, podName string, containerName string) error
 }
@@ -102,7 +102,7 @@ func (k *KubernetesApiServiceImpl) DeletePod(podName string) error {
 	return err
 }
 
-func (k *KubernetesApiServiceImpl) CreatePrivilegedPod(nodeName string, image string) (*corev1.Pod, error) {
+func (k *KubernetesApiServiceImpl) CreatePrivilegedPod(nodeName string, image string, timeout time.Duration) (*corev1.Pod, error) {
 	log.Debugf("creating privileged pod on remote node")
 
 	isSupported, err := k.IsSupportedContainerRuntime(nodeName)
@@ -194,9 +194,8 @@ func (k *KubernetesApiServiceImpl) CreatePrivilegedPod(nodeName string, image st
 
 	log.Info("waiting for pod successful startup")
 
-	podCreationTimeout := 1 * time.Minute
-	if !utils.RunWhileFalse(verifyPodState, podCreationTimeout, 1*time.Second) {
-		return nil, errors.Errorf("failed to create pod within timeout (%s)", podCreationTimeout)
+	if !utils.RunWhileFalse(verifyPodState, timeout, 1*time.Second) {
+		return nil, errors.Errorf("failed to create pod within timeout (%s)", timeout)
 	}
 
 	return createdPod, nil

--- a/pkg/cmd/sniff.go
+++ b/pkg/cmd/sniff.go
@@ -121,6 +121,10 @@ func NewCmdSniff(streams genericclioptions.IOStreams) *cobra.Command {
 	_ = viper.BindEnv("privileged", "KUBECTL_PLUGINS_LOCAL_FLAG_PRIVILEGED")
 	_ = viper.BindPFlag("privileged", cmd.Flags().Lookup("privileged"))
 
+	cmd.Flags().DurationVarP(&ksniffSettings.UserSpecifiedPodCreateTimeout, "pod-creation-timeout", "",
+		1 * time.Minute, "the length of time to wait for privileged pod to be created (e.g. 20s, 2m, 1h). " +
+		"A value of zero means the creation never times out.")
+
 	cmd.Flags().StringVarP(&ksniffSettings.Image, "image", "", "",
 		"the privileged container image (optional)")
 	_ = viper.BindEnv("image", "KUBECTL_PLUGINS_LOCAL_FLAG_IMAGE")

--- a/pkg/config/settings.go
+++ b/pkg/config/settings.go
@@ -2,12 +2,14 @@ package config
 
 import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"time"
 )
 
 type KsniffSettings struct {
 	UserSpecifiedPodName           string
 	UserSpecifiedInterface         string
 	UserSpecifiedFilter            string
+	UserSpecifiedPodCreateTimeout  time.Duration
 	UserSpecifiedContainer         string
 	UserSpecifiedNamespace         string
 	UserSpecifiedOutputFile        string

--- a/pkg/service/sniffer/privileged_pod_sniffer_service.go
+++ b/pkg/service/sniffer/privileged_pod_sniffer_service.go
@@ -34,7 +34,7 @@ func (p *PrivilegedPodSnifferService) Setup() error {
 		image = p.runtimeBridge.GetDefaultImage()
 	}
 
-	p.privilegedPod, err = p.kubernetesApiService.CreatePrivilegedPod(p.settings.DetectedPodNodeName, image)
+	p.privilegedPod, err = p.kubernetesApiService.CreatePrivilegedPod(p.settings.DetectedPodNodeName, image, p.settings.UserSpecifiedPodCreateTimeout)
 	if err != nil {
 		log.WithError(err).Errorf("failed to create privileged pod on node: '%s'", p.settings.DetectedPodNodeName)
 		return err

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -1,0 +1,74 @@
+package utils
+
+import (
+	"context"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func TestRunWhileFalse_Instant(t *testing.T) {
+	// given
+	f := func() bool {
+		return true
+	}
+
+	// when
+	result := RunWhileFalse(f, time.Minute, time.Minute)
+
+	// then
+	assert.True(t, result)
+}
+
+func TestRunWhileFalse_1SecTimeoutFalse(t *testing.T) {
+	// given
+	f := func() bool {
+		return false
+	}
+
+	// when
+	begin := time.Now()
+	result := RunWhileFalse(f, time.Second, time.Second)
+	end := time.Now()
+	diff := end.Sub(begin)
+
+	// then
+	assert.False(t, result)
+	assert.True(t, (diff.Seconds() > 0 && diff.Seconds() < 2))
+}
+
+func TestRunWhileFalse_NoTimeout(t *testing.T) {
+	// given
+	f := func() bool {
+		return false
+	}
+	// This part is tricky since we don't want our test case to run forever.
+	// Adding a timeout outside scope of RunWhileFalse
+	ctx, cancel := context.WithTimeout(context.Background(), 1 * time.Second)
+	defer cancel()
+
+	// when
+	go func() {
+		RunWhileFalse(f, 0*time.Second, time.Second)
+		cancel()
+	}()
+
+	// then
+	<- ctx.Done()
+	assert.Equal(t, context.DeadlineExceeded, ctx.Err())
+}
+
+func TestRuneWhileFalse_1SecTimeoutTrue(t *testing.T) {
+	// given
+	ret := false
+	f := func() bool {
+		return ret
+	}
+	time.AfterFunc(1 * time.Second, func() { ret = true })
+
+	// when
+	result := RunWhileFalse(f, 5*time.Second, time.Second)
+
+	// then
+	assert.True(t, result)
+}


### PR DESCRIPTION
Adds a new flag `--pod-creation-timeout` that accepts a duration value like 30s, 2m, 1h, etc. 