### PR TITLE
:bug: Use chroot to execute docker command

### DIFF
--- a/pkg/service/sniffer/runtime/docker.go
+++ b/pkg/service/sniffer/runtime/docker.go
@@ -29,7 +29,7 @@ func (d DockerBridge) BuildTcpdumpCommand(containerId *string, netInterface stri
 	d.tcpdumpContainerName = "ksniff-container-" + utils.GenerateRandomString(8)
 	containerNameFlag := fmt.Sprintf("--name=%s", d.tcpdumpContainerName)
 
-	command := []string{"docker", "--host", "unix:///host/var/run/docker.sock",
+	command := []string{"chroot", "/host", "docker", "--host", "unix:///var/run/docker.sock",
 		"run", "--rm", containerNameFlag,
 		fmt.Sprintf("--net=container:%s", *containerId), "maintained/tcpdump", "-i",
 		netInterface, "-U", "-w", "-", filter}


### PR DESCRIPTION
The current version of sniff plugin is not working with last version of AKS.
This fix use chroot to launch docker command directly.