### PR TITLE
Optional socket path argument and fallback to default soket path

### DIFF
--- a/kube/kubernetes_api_service.go
+++ b/kube/kubernetes_api_service.go
@@ -128,11 +128,18 @@ func (k *KubernetesApiServiceImpl) CreatePrivilegedPod(nodeName string, image st
 		},
 	}
 
-	volumeMounts := []corev1.VolumeMount{{
-		Name:      "container-socket",
-		ReadOnly:  true,
-		MountPath: socketPath,
-	}}
+	volumeMounts := []corev1.VolumeMount{
+		{
+			Name:      "container-socket",
+			ReadOnly:  true,
+			MountPath: socketPath,
+		},
+		{
+			Name:      "host",
+			ReadOnly:  false,
+			MountPath: "/host",
+		},
+	}
 
 	privileged := true
 	privilegedContainer := corev1.Container{
@@ -148,12 +155,7 @@ func (k *KubernetesApiServiceImpl) CreatePrivilegedPod(nodeName string, image st
 	}
 
 	hostPathType := corev1.HostPathSocket
-	volumeSources := corev1.VolumeSource{
-		HostPath: &corev1.HostPathVolumeSource{
-			Path: socketPath,
-			Type: &hostPathType,
-		},
-	}
+	directoryType := corev1.HostPathDirectory
 
 	podSpecs := corev1.PodSpec{
 		NodeName:      nodeName,
@@ -162,8 +164,22 @@ func (k *KubernetesApiServiceImpl) CreatePrivilegedPod(nodeName string, image st
 		Containers:    []corev1.Container{privilegedContainer},
 		Volumes: []corev1.Volume{
 			{
-				Name:         "container-socket",
-				VolumeSource: volumeSources,
+				Name: "host",
+				VolumeSource: corev1.VolumeSource{
+					HostPath: &corev1.HostPathVolumeSource{
+						Path: "/",
+						Type: &directoryType,
+					},
+				},
+			},
+			{
+				Name: "container-socket",
+				VolumeSource: corev1.VolumeSource{
+					HostPath: &corev1.HostPathVolumeSource{
+						Path: socketPath,
+						Type: &hostPathType,
+					},
+				},
 			},
 		},
 	}

--- a/kube/kubernetes_api_service.go
+++ b/kube/kubernetes_api_service.go
@@ -147,7 +147,7 @@ func (k *KubernetesApiServiceImpl) CreatePrivilegedPod(nodeName string, image st
 		VolumeMounts: volumeMounts,
 	}
 
-	hostPathType := corev1.HostPathFile
+	hostPathType := corev1.HostPathSocket
 	volumeSources := corev1.VolumeSource{
 		HostPath: &corev1.HostPathVolumeSource{
 			Path: socketPath,

--- a/kube/ops.go
+++ b/kube/ops.go
@@ -144,7 +144,7 @@ func PodExecuteCommand(req ExecCommandRequest) (int, error) {
 	if err != nil {
 		if exitErr, ok := err.(utilexec.ExitError); ok && exitErr.Exited() {
 			exitCode = exitErr.ExitStatus()
-			err = nil
+			err = exitErr
 		}
 	}
 

--- a/pkg/config/settings.go
+++ b/pkg/config/settings.go
@@ -24,6 +24,8 @@ type KsniffSettings struct {
 	Image                          string
 	UseDefaultImage                bool
 	UserSpecifiedKubeContext       string
+	SocketPath                     string
+	UseDefaultSocketPath           bool
 }
 
 func NewKsniffSettings(streams genericclioptions.IOStreams) *KsniffSettings {

--- a/pkg/service/sniffer/runtime/crio.go
+++ b/pkg/service/sniffer/runtime/crio.go
@@ -9,20 +9,20 @@ import (
 type CrioBridge struct {
 }
 
-func NewCrioBridge() CrioBridge {
-	return CrioBridge{}
+func NewCrioBridge() *CrioBridge {
+	return &CrioBridge{}
 }
 
-func (c CrioBridge) NeedsPid() bool {
+func (c *CrioBridge) NeedsPid() bool {
 	return true
 }
 
-func (c CrioBridge) BuildInspectCommand(containerId string) []string {
+func (c *CrioBridge) BuildInspectCommand(containerId string) []string {
 	return []string{"chroot", "/host", "crictl", "inspect",
 		"--output", "json", containerId}
 }
 
-func (c CrioBridge) ExtractPid(inspection string) (*string, error) {
+func (c *CrioBridge) ExtractPid(inspection string) (*string, error) {
 	var result map[string]json.RawMessage
 	var pid float64
 	var err error
@@ -51,16 +51,20 @@ func (c CrioBridge) ExtractPid(inspection string) (*string, error) {
 	return &ret, nil
 }
 
-func (c CrioBridge) BuildTcpdumpCommand(containerId *string, netInterface string, filter string, pid *string) []string {
+func (c *CrioBridge) BuildTcpdumpCommand(containerId *string, netInterface string, filter string, pid *string) []string {
 	return []string{"nsenter", "-n", "-t", *pid, "--", "tcpdump", "-i", netInterface, "-U", "-w", "-", filter}
 }
 
-func (c CrioBridge) BuildCleanupCommand() []string {
+func (c *CrioBridge) BuildCleanupCommand() []string {
 	return nil // No cleanup needed
 }
 
-func (c CrioBridge) GetDefaultImage() string {
+func (c *CrioBridge) GetDefaultImage() string {
 	return "maintained/tcpdump"
+}
+
+func (c *CrioBridge) GetDefaultSocketPath() string {
+	return "/var/run/crio/crio.sock"
 }
 
 // CRI-O 1.17 and older have pid as first-level attribute

--- a/pkg/service/sniffer/runtime/crio.go
+++ b/pkg/service/sniffer/runtime/crio.go
@@ -51,7 +51,7 @@ func (c *CrioBridge) ExtractPid(inspection string) (*string, error) {
 	return &ret, nil
 }
 
-func (c *CrioBridge) BuildTcpdumpCommand(containerId *string, netInterface string, filter string, pid *string) []string {
+func (c *CrioBridge) BuildTcpdumpCommand(containerId *string, netInterface string, filter string, pid *string, socketPath string) []string {
 	return []string{"nsenter", "-n", "-t", *pid, "--", "tcpdump", "-i", netInterface, "-U", "-w", "-", filter}
 }
 

--- a/pkg/service/sniffer/runtime/docker.go
+++ b/pkg/service/sniffer/runtime/docker.go
@@ -26,11 +26,11 @@ func (d *DockerBridge) ExtractPid(inspection string) (*string, error) {
 	panic("Docker doesn't need this implemented")
 }
 
-func (d *DockerBridge) BuildTcpdumpCommand(containerId *string, netInterface string, filter string, pid *string) []string {
+func (d *DockerBridge) BuildTcpdumpCommand(containerId *string, netInterface string, filter string, pid *string, socketPath string) []string {
 	d.tcpdumpContainerName = "ksniff-container-" + utils.GenerateRandomString(8)
 	containerNameFlag := fmt.Sprintf("--name=%s", d.tcpdumpContainerName)
 
-	command := []string{"docker", "--host", "unix://" + d.GetDefaultSocketPath(),
+	command := []string{"docker", "--host", "unix://" + socketPath,
 		"run", "--rm", containerNameFlag,
 		fmt.Sprintf("--net=container:%s", *containerId), "maintained/tcpdump", "-i",
 		netInterface, "-U", "-w", "-", filter}

--- a/pkg/service/sniffer/runtime/docker.go
+++ b/pkg/service/sniffer/runtime/docker.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"fmt"
+
 	"ksniff/utils"
 )
 
@@ -9,27 +10,27 @@ type DockerBridge struct {
 	tcpdumpContainerName string
 }
 
-func NewDockerBridge() DockerBridge{
-	return DockerBridge{}
+func NewDockerBridge() *DockerBridge {
+	return &DockerBridge{}
 }
 
-func (d DockerBridge) NeedsPid() bool {
+func (d *DockerBridge) NeedsPid() bool {
 	return false
 }
 
-func (d DockerBridge) BuildInspectCommand(string) []string {
+func (d *DockerBridge) BuildInspectCommand(string) []string {
 	panic("Docker doesn't need this implemented")
 }
 
-func (d DockerBridge) ExtractPid(inspection string) (*string, error) {
+func (d *DockerBridge) ExtractPid(inspection string) (*string, error) {
 	panic("Docker doesn't need this implemented")
 }
 
-func (d DockerBridge) BuildTcpdumpCommand(containerId *string, netInterface string, filter string, pid *string) []string {
+func (d *DockerBridge) BuildTcpdumpCommand(containerId *string, netInterface string, filter string, pid *string) []string {
 	d.tcpdumpContainerName = "ksniff-container-" + utils.GenerateRandomString(8)
 	containerNameFlag := fmt.Sprintf("--name=%s", d.tcpdumpContainerName)
 
-	command := []string{"docker", "--host", "unix:///host/var/run/docker.sock",
+	command := []string{"docker", "--host", "unix://" + d.GetDefaultSocketPath(),
 		"run", "--rm", containerNameFlag,
 		fmt.Sprintf("--net=container:%s", *containerId), "maintained/tcpdump", "-i",
 		netInterface, "-U", "-w", "-", filter}
@@ -37,10 +38,14 @@ func (d DockerBridge) BuildTcpdumpCommand(containerId *string, netInterface stri
 	return command
 }
 
-func (d DockerBridge) BuildCleanupCommand() []string {
+func (d *DockerBridge) BuildCleanupCommand() []string {
 	return []string{"docker", "rm", "-f", d.tcpdumpContainerName}
 }
 
-func (d DockerBridge) GetDefaultImage() string {
+func (d *DockerBridge) GetDefaultImage() string {
 	return "docker"
+}
+
+func (d *DockerBridge) GetDefaultSocketPath() string {
+	return "/var/run/docker.sock"
 }

--- a/pkg/service/sniffer/runtime/runtime.go
+++ b/pkg/service/sniffer/runtime/runtime.go
@@ -2,7 +2,7 @@ package runtime
 
 import "fmt"
 
-var SupportedContainerRuntimes = []string {
+var SupportedContainerRuntimes = []string{
 	"docker",
 	"cri-o",
 }
@@ -14,6 +14,7 @@ type ContainerRuntimeBridge interface {
 	BuildTcpdumpCommand(containerId *string, netInterface string, filter string, pid *string) []string
 	BuildCleanupCommand() []string
 	GetDefaultImage() string
+	GetDefaultSocketPath() string
 }
 
 func NewContainerRuntimeBridge(runtimeName string) ContainerRuntimeBridge {

--- a/pkg/service/sniffer/runtime/runtime.go
+++ b/pkg/service/sniffer/runtime/runtime.go
@@ -11,7 +11,7 @@ type ContainerRuntimeBridge interface {
 	NeedsPid() bool
 	BuildInspectCommand(containerId string) []string
 	ExtractPid(inspection string) (*string, error)
-	BuildTcpdumpCommand(containerId *string, netInterface string, filter string, pid *string) []string
+	BuildTcpdumpCommand(containerId *string, netInterface string, filter string, pid *string, socketPath string) []string
 	BuildCleanupCommand() []string
 	GetDefaultImage() string
 	GetDefaultSocketPath() string

--- a/pkg/service/sniffer/runtime/runtime_test.go
+++ b/pkg/service/sniffer/runtime/runtime_test.go
@@ -7,14 +7,14 @@ import (
 
 func TestNewContainerRuntimeBridge_Docker(t *testing.T) {
 	bridge := NewContainerRuntimeBridge("docker")
-	assert.IsType(t, DockerBridge{}, bridge)
+	assert.IsType(t, &DockerBridge{}, bridge)
 }
 
 func TestNewContainerRuntimeBridge_Crio(t *testing.T) {
 	bridge := NewContainerRuntimeBridge("cri-o")
-	assert.IsType(t, CrioBridge{}, bridge)
+	assert.IsType(t, &CrioBridge{}, bridge)
 }
 
 func TestNewContainerRuntimeBridge_Invalid(t *testing.T) {
-	assert.Panics(t, func(){ NewContainerRuntimeBridge("i-do-not-exist") })
+	assert.Panics(t, func() { NewContainerRuntimeBridge("i-do-not-exist") })
 }


### PR DESCRIPTION
Fixed #87, #82.

Changes:
1. Added a default socket path for each runtime (e.g. `/var/run/docker.sock` for docker);
2. A new `socket` argument for passing in the socket path to support the scenario that the socket path is different from the default path (e.g. the `DOCKER_SOCKET` is changed to another path in the docker conf);
3. Changed `DockerBridge` and `CrioBridge` to pointer receivers. This fixed the `BuildCleanupCommand` in `DockerBridge` too.
4. Return the overlooked error in `kube/ops.go` and `pkg/service/sniffer/privileged_pod_sniffer_service.go` so that the error is propagated back and trigger the cleanup as expected.

Note: Some code formatting changes due to the auto `gofmt` on my side.