### PR TITLE
ls: /tmp/static-tcpdump: No such file or directory (#103)

### DIFF
--- a/kube/kubernetes_api_service.go
+++ b/kube/kubernetes_api_service.go
@@ -224,7 +224,7 @@ func (k *KubernetesApiServiceImpl) checkIfFileExistOnPod(remotePath string, podN
 	stdOut := new(Writer)
 	stdErr := new(Writer)
 
-	command := []string{"/bin/sh", "-c", fmt.Sprintf("ls -alt %s", remotePath)}
+	command := []string{"/bin/sh", "-c", fmt.Sprintf("test -f %s", remotePath)}
 
 	exitCode, err := k.ExecuteCommand(podName, containerName, command, stdOut)
 	if err != nil {


### PR DESCRIPTION
ls command results in error messages when listing non-existing path.
Use shell command 'test -f' to check whether file exists.