### PR TITLE
Allow air gapped envs to use ksniff

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ To compile a static tcpdump binary:
     LOCAL_TCPDUMP_FILE: Optional. if specified, ksniff will use this path as the local path of the static tcpdump binary.
     REMOTE_TCPDUMP_FILE: Optional. if specified, ksniff will use the specified path as the remote path to upload static tcpdump to.
 
+#### Air gapped environments
+Use `--image` and `--tcpdump-image` flags to override the default container images and use your own e.g (docker):
+  
+    kubectl plugin sniff <POD_NAME> [-n <NAMESPACE_NAME>] [-c <CONTAINER_NAME>] --image <PRIVATE_REPO>/docker --tcpdump-image <PRIVATE_REPO>/tcpdump
+   
+
 #### Non-Privileged and Scratch Pods
 To reduce attack surface and have small and lean containers, many production-ready containers runs as non-privileged user
 or even as a scratch container.

--- a/pkg/cmd/sniff.go
+++ b/pkg/cmd/sniff.go
@@ -131,6 +131,11 @@ func NewCmdSniff(streams genericclioptions.IOStreams) *cobra.Command {
 	_ = viper.BindEnv("image", "KUBECTL_PLUGINS_LOCAL_FLAG_IMAGE")
 	_ = viper.BindPFlag("image", cmd.Flags().Lookup("image"))
 
+	cmd.Flags().StringVarP(&ksniffSettings.TCPDumpImage, "tcpdump-image", "", "",
+		"the tcpdump container image (optional)")
+	_ = viper.BindEnv("tcpdump-image", "KUBECTL_PLUGINS_LOCAL_FLAG_TCPDUMP_IMAGE")
+	_ = viper.BindPFlag("tcpdump-image", cmd.Flags().Lookup("tcpdump-image"))
+
 	cmd.Flags().StringVarP(&ksniffSettings.UserSpecifiedKubeContext, "context", "x", "",
 		"kubectl context to work on (optional)")
 	_ = viper.BindEnv("context", "KUBECTL_PLUGINS_CURRENT_CONTEXT")
@@ -167,6 +172,7 @@ func (o *Ksniff) Complete(cmd *cobra.Command, args []string) error {
 	o.settings.UserSpecifiedPrivilegedMode = viper.GetBool("privileged")
 	o.settings.UserSpecifiedKubeContext = viper.GetString("context")
 	o.settings.UseDefaultImage = !cmd.Flag("image").Changed
+	o.settings.UseDefaultTCPDumpImage = !cmd.Flag("tcpdump-image").Changed
 	o.settings.UseDefaultSocketPath = !cmd.Flag("socket").Changed
 
 	var err error

--- a/pkg/config/settings.go
+++ b/pkg/config/settings.go
@@ -22,7 +22,9 @@ type KsniffSettings struct {
 	DetectedContainerId            string
 	DetectedContainerRuntime       string
 	Image                          string
+	TCPDumpImage				   string
 	UseDefaultImage                bool
+	UseDefaultTCPDumpImage		   bool
 	UserSpecifiedKubeContext       string
 	SocketPath                     string
 	UseDefaultSocketPath           bool

--- a/pkg/config/settings.go
+++ b/pkg/config/settings.go
@@ -22,9 +22,9 @@ type KsniffSettings struct {
 	DetectedContainerId            string
 	DetectedContainerRuntime       string
 	Image                          string
-	TCPDumpImage				   string
+	TCPDumpImage                   string
 	UseDefaultImage                bool
-	UseDefaultTCPDumpImage		   bool
+	UseDefaultTCPDumpImage         bool
 	UserSpecifiedKubeContext       string
 	SocketPath                     string
 	UseDefaultSocketPath           bool

--- a/pkg/service/sniffer/privileged_pod_sniffer_service.go
+++ b/pkg/service/sniffer/privileged_pod_sniffer_service.go
@@ -33,6 +33,10 @@ func (p *PrivilegedPodSnifferService) Setup() error {
 		p.settings.Image = p.runtimeBridge.GetDefaultImage()
 	}
 
+	if p.settings.UseDefaultTCPDumpImage {
+		p.settings.TCPDumpImage = p.runtimeBridge.GetDefaultTCPImage()
+	}
+
 	if p.settings.UseDefaultSocketPath {
 		p.settings.SocketPath = p.runtimeBridge.GetDefaultSocketPath()
 	}
@@ -102,6 +106,7 @@ func (p *PrivilegedPodSnifferService) Start(stdOut io.Writer) error {
 		p.settings.UserSpecifiedFilter,
 		p.targetProcessId,
 		p.settings.SocketPath,
+		p.settings.TCPDumpImage,
 	)
 
 	exitCode, err := p.kubernetesApiService.ExecuteCommand(p.privilegedPod.Name, p.privilegedContainerName, command, stdOut)

--- a/pkg/service/sniffer/runtime/crio.go
+++ b/pkg/service/sniffer/runtime/crio.go
@@ -52,7 +52,7 @@ func (c *CrioBridge) ExtractPid(inspection string) (*string, error) {
 	return &ret, nil
 }
 
-func (c *CrioBridge) BuildTcpdumpCommand(containerId *string, netInterface string, filter string, pid *string, socketPath string) []string {
+func (c *CrioBridge) BuildTcpdumpCommand(containerId *string, netInterface string, filter string, pid *string, socketPath string, tcpdumpImage string) []string {
 	return []string{"nsenter", "-n", "-t", *pid, "--", "tcpdump", "-i", netInterface, "-U", "-w", "-", filter}
 }
 
@@ -86,4 +86,8 @@ func extractPidCrio118(partial map[string]json.RawMessage) (float64, error) {
 		return -1, err
 	}
 	return result["pid"].(float64), nil
+}
+
+func (d *CrioBridge) GetDefaultTCPImage() string {
+	return ""
 }

--- a/pkg/service/sniffer/runtime/docker.go
+++ b/pkg/service/sniffer/runtime/docker.go
@@ -27,13 +27,13 @@ func (d *DockerBridge) ExtractPid(inspection string) (*string, error) {
 	panic("Docker doesn't need this implemented")
 }
 
-func (d *DockerBridge) BuildTcpdumpCommand(containerId *string, netInterface string, filter string, pid *string, socketPath string) []string {
+func (d *DockerBridge) BuildTcpdumpCommand(containerId *string, netInterface string, filter string, pid *string, socketPath string, tcpdumpImage string) []string {
 	d.tcpdumpContainerName = "ksniff-container-" + utils.GenerateRandomString(8)
 	containerNameFlag := fmt.Sprintf("--name=%s", d.tcpdumpContainerName)
 
 	command := []string{"docker", "--host", "unix://" + socketPath,
 		"run", "--rm", containerNameFlag,
-		fmt.Sprintf("--net=container:%s", *containerId), "maintained/tcpdump", "-i",
+		fmt.Sprintf("--net=container:%s", *containerId), tcpdumpImage, "-i",
 		netInterface, "-U", "-w", "-", filter}
 
 	d.cleanupCommand = []string{"docker", "--host", "unix://" + socketPath,
@@ -48,6 +48,10 @@ func (d *DockerBridge) BuildCleanupCommand() []string {
 
 func (d *DockerBridge) GetDefaultImage() string {
 	return "docker"
+}
+
+func (d *DockerBridge) GetDefaultTCPImage() string {
+	return "maintained/tcpdump"
 }
 
 func (d *DockerBridge) GetDefaultSocketPath() string {

--- a/pkg/service/sniffer/runtime/docker_test.go
+++ b/pkg/service/sniffer/runtime/docker_test.go
@@ -23,7 +23,8 @@ func TestPrivilegedPodName(t *testing.T) {
 	var filter = "filter"
 	var pid = "pid"
 	var path = "/path"
-	bridge.BuildTcpdumpCommand(&containerId, netInterface, filter, &pid, path)
+	var tcpdumpImage = bridge.GetDefaultTCPImage()
+	bridge.BuildTcpdumpCommand(&containerId, netInterface, filter, &pid, path, tcpdumpImage)
 	assert.NotEqual(t, "", bridge.tcpdumpContainerName, "tcpdumpContainerName should have been set")
 }
 
@@ -34,7 +35,8 @@ func TestCleanupCommand(t *testing.T) {
 	var filter = "filter"
 	var pid = "pid"
 	var socketPath = "/path"
-	bridge.BuildTcpdumpCommand(&containerId, netInterface, filter, &pid, socketPath)
+	var tcpdumpImage = bridge.GetDefaultTCPImage()
+	bridge.BuildTcpdumpCommand(&containerId, netInterface, filter, &pid, socketPath, tcpdumpImage)
 	assert.Equal(t,
 		[]string{"docker", "--host", "unix://" + socketPath, "rm", "-f", bridge.tcpdumpContainerName},
 		bridge.BuildCleanupCommand(),

--- a/pkg/service/sniffer/runtime/runtime.go
+++ b/pkg/service/sniffer/runtime/runtime.go
@@ -12,9 +12,10 @@ type ContainerRuntimeBridge interface {
 	NeedsPid() bool
 	BuildInspectCommand(containerId string) []string
 	ExtractPid(inspection string) (*string, error)
-	BuildTcpdumpCommand(containerId *string, netInterface string, filter string, pid *string, socketPath string) []string
+	BuildTcpdumpCommand(containerId *string, netInterface string, filter string, pid *string, socketPath string, tcpdumpImage string) []string
 	BuildCleanupCommand() []string
 	GetDefaultImage() string
+	GetDefaultTCPImage() string
 	GetDefaultSocketPath() string
 }
 


### PR DESCRIPTION
This PR will allow the use of custom tcpdump docker image for when you run in an air gapped environment.