### PR TITLE
Allow selecting a specific service account for privileged containers

### DIFF
--- a/kube/kubernetes_api_service.go
+++ b/kube/kubernetes_api_service.go
@@ -25,7 +25,7 @@ type KubernetesApiService interface {
 
 	DeletePod(podName string) error
 
-	CreatePrivilegedPod(nodeName string, containerName string, image string, socketPath string, timeout time.Duration) (*corev1.Pod, error)
+	CreatePrivilegedPod(nodeName string, containerName string, image string, socketPath string, timeout time.Duration, serviceaccount string) (*corev1.Pod, error)
 
 	UploadFile(localPath string, remotePath string, podName string, containerName string) error
 }
@@ -102,7 +102,7 @@ func (k *KubernetesApiServiceImpl) DeletePod(podName string) error {
 	return err
 }
 
-func (k *KubernetesApiServiceImpl) CreatePrivilegedPod(nodeName string, containerName string, image string, socketPath string, timeout time.Duration) (*corev1.Pod, error) {
+func (k *KubernetesApiServiceImpl) CreatePrivilegedPod(nodeName string, containerName string, image string, socketPath string, timeout time.Duration, serviceaccount string) (*corev1.Pod, error) {
 	log.Debugf("creating privileged pod on remote node")
 
 	isSupported, err := k.IsSupportedContainerRuntime(nodeName)
@@ -192,6 +192,10 @@ func (k *KubernetesApiServiceImpl) CreatePrivilegedPod(nodeName string, containe
 				},
 			},
 		},
+	}
+
+	if serviceaccount != "" {
+		podSpecs.ServiceAccountName = serviceaccount
 	}
 
 	pod := corev1.Pod{

--- a/pkg/config/settings.go
+++ b/pkg/config/settings.go
@@ -1,8 +1,9 @@
 package config
 
 import (
-	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"time"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
 type KsniffSettings struct {
@@ -28,6 +29,7 @@ type KsniffSettings struct {
 	UserSpecifiedKubeContext       string
 	SocketPath                     string
 	UseDefaultSocketPath           bool
+	UserSpecifiedServiceAccount    string
 }
 
 func NewKsniffSettings(streams genericclioptions.IOStreams) *KsniffSettings {

--- a/pkg/service/sniffer/privileged_pod_sniffer_service.go
+++ b/pkg/service/sniffer/privileged_pod_sniffer_service.go
@@ -48,6 +48,7 @@ func (p *PrivilegedPodSnifferService) Setup() error {
 		p.settings.Image,
 		p.settings.SocketPath,
 		p.settings.UserSpecifiedPodCreateTimeout,
+		p.settings.UserSpecifiedServiceAccount,
 	)
 	if err != nil {
 		log.WithError(err).Errorf("failed to create privileged pod on node: '%s'", p.settings.DetectedPodNodeName)


### PR DESCRIPTION
Hello,

Thanks for this very useful tool.
Could I suggest this small PR?
I run a project in an openshift cluster. I use a specific debug service account for debugging tools, which is the only one that can access to privileged scc is our namespace.
I would like to be able to set a specific service account in the privileged container to avoid requesting privileges for the default SA.

What do you think?