### PR TITLE
Isolate Sniffers from Ksniff-wide Settings to avoid any side-affects

### DIFF
--- a/pkg/config/settings.go
+++ b/pkg/config/settings.go
@@ -43,6 +43,15 @@ type PrivilegedSnifferServiceConfig struct {
 	UserSpecifiedPodCreateTimeout time.Duration
 }
 
+type StaticTCPSnifferServiceConfig struct {
+	UserSpecifiedLocalTcpdumpPath  string
+	UserSpecifiedRemoteTcpdumpPath string
+	UserSpecifiedPodName           string
+	UserSpecifiedContainer         string
+	UserSpecifiedInterface         string
+	UserSpecifiedFilter            string
+}
+
 func NewKsniffSettings(streams genericclioptions.IOStreams) *KsniffSettings {
 	return &KsniffSettings{}
 }

--- a/pkg/config/settings.go
+++ b/pkg/config/settings.go
@@ -1,8 +1,9 @@
 package config
 
 import (
-	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"time"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
 type KsniffSettings struct {
@@ -28,6 +29,18 @@ type KsniffSettings struct {
 	UserSpecifiedKubeContext       string
 	SocketPath                     string
 	UseDefaultSocketPath           bool
+}
+
+type PrivilegedSnifferServiceConfig struct {
+	DetectedContainerId           string
+	DetectedContainerRuntime      string
+	Image                         string
+	TCPDumpImage                  string
+	SocketPath                    string
+	DetectedPodNodeName           string
+	UserSpecifiedInterface        string
+	UserSpecifiedFilter           string
+	UserSpecifiedPodCreateTimeout time.Duration
 }
 
 func NewKsniffSettings(streams genericclioptions.IOStreams) *KsniffSettings {

--- a/pkg/service/sniffer/privileged_pod_sniffer_service.go
+++ b/pkg/service/sniffer/privileged_pod_sniffer_service.go
@@ -2,62 +2,93 @@ package sniffer
 
 import (
 	"bytes"
+	"fmt"
 	"io"
+	"strings"
 
-	log "github.com/sirupsen/logrus"
-	v1 "k8s.io/api/core/v1"
 	"ksniff/kube"
 	"ksniff/pkg/config"
 	"ksniff/pkg/service/sniffer/runtime"
+
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
 )
 
 type PrivilegedPodSnifferService struct {
-	settings                *config.KsniffSettings
-	privilegedPod           *v1.Pod
+	*config.PrivilegedSnifferServiceConfig
+	privilegedPod           *corev1.Pod
 	privilegedContainerName string
 	targetProcessId         *string
 	kubernetesApiService    kube.KubernetesApiService
 	runtimeBridge           runtime.ContainerRuntimeBridge
 }
 
-func NewPrivilegedPodRemoteSniffingService(options *config.KsniffSettings, service kube.KubernetesApiService, bridge runtime.ContainerRuntimeBridge) SnifferService {
-	return &PrivilegedPodSnifferService{settings: options, privilegedContainerName: "ksniff-privileged", kubernetesApiService: service, runtimeBridge: bridge}
+
+func NewPrivilegedPodRemoteSniffingService(knsiffSettings *config.KsniffSettings, pod *corev1.Pod, service kube.KubernetesApiService) (SnifferService, error) {
+	runtimeStr, containerID, err := getPodContainerRuntimeDetails(pod)
+
+	if err != nil {
+		return nil, err
+	}
+
+	bridge := runtime.NewContainerRuntimeBridge(runtimeStr)
+
+	snifferService := &PrivilegedPodSnifferService{
+		privilegedContainerName: "ksniff-privileged",
+		kubernetesApiService:    service,
+		runtimeBridge:           bridge,
+		PrivilegedSnifferServiceConfig: &config.PrivilegedSnifferServiceConfig{
+			DetectedContainerId:           containerID,
+			DetectedContainerRuntime:      runtimeStr,
+			Image:                         knsiffSettings.Image,
+			TCPDumpImage:                  knsiffSettings.TCPDumpImage,
+			SocketPath:                    knsiffSettings.SocketPath,
+			DetectedPodNodeName:           knsiffSettings.DetectedPodNodeName,
+			UserSpecifiedInterface:        knsiffSettings.UserSpecifiedInterface,
+			UserSpecifiedFilter:           knsiffSettings.UserSpecifiedFilter,
+			UserSpecifiedPodCreateTimeout: knsiffSettings.UserSpecifiedPodCreateTimeout,
+		},
+	}
+	// Overwrite with defaults if not specified
+	if knsiffSettings.UseDefaultImage {
+		snifferService.Image = snifferService.runtimeBridge.GetDefaultImage()
+	}
+
+	if knsiffSettings.UseDefaultTCPDumpImage {
+		snifferService.TCPDumpImage = snifferService.runtimeBridge.GetDefaultTCPImage()
+	}
+
+	if knsiffSettings.UseDefaultSocketPath {
+		snifferService.SocketPath = snifferService.runtimeBridge.GetDefaultSocketPath()
+	}
+	
+
+	return snifferService, nil
+
 }
 
 func (p *PrivilegedPodSnifferService) Setup() error {
 	var err error
 
-	log.Infof("creating privileged pod on node: '%s'", p.settings.DetectedPodNodeName)
-
-	if p.settings.UseDefaultImage {
-		p.settings.Image = p.runtimeBridge.GetDefaultImage()
-	}
-
-	if p.settings.UseDefaultTCPDumpImage {
-		p.settings.TCPDumpImage = p.runtimeBridge.GetDefaultTCPImage()
-	}
-
-	if p.settings.UseDefaultSocketPath {
-		p.settings.SocketPath = p.runtimeBridge.GetDefaultSocketPath()
-	}
-
+	log.Infof("creating privileged pod on node: '%s'", p.DetectedPodNodeName)
 	p.privilegedPod, err = p.kubernetesApiService.CreatePrivilegedPod(
-		p.settings.DetectedPodNodeName,
+		p.DetectedPodNodeName,
 		p.privilegedContainerName,
-		p.settings.Image,
-		p.settings.SocketPath,
-		p.settings.UserSpecifiedPodCreateTimeout,
+		p.Image,
+		p.SocketPath,
+		p.UserSpecifiedPodCreateTimeout,
 	)
 	if err != nil {
-		log.WithError(err).Errorf("failed to create privileged pod on node: '%s'", p.settings.DetectedPodNodeName)
+		log.WithError(err).Errorf("failed to create privileged pod on node: '%s'", p.DetectedPodNodeName)
 		return err
 	}
 
-	log.Infof("pod: '%s' created successfully on node: '%s'", p.privilegedPod.Name, p.settings.DetectedPodNodeName)
+	log.Infof("pod: '%s' created successfully on node: '%s'", p.privilegedPod.Name, p.DetectedPodNodeName)
 
 	if p.runtimeBridge.NeedsPid() {
 		var buff bytes.Buffer
-		command := p.runtimeBridge.BuildInspectCommand(p.settings.DetectedContainerId)
+		command := p.runtimeBridge.BuildInspectCommand(p.DetectedContainerId)
 		exitCode, err := p.kubernetesApiService.ExecuteCommand(p.privilegedPod.Name, p.privilegedContainerName, command, &buff)
 		if err != nil {
 			log.WithError(err).Errorf("failed to start sniffing using privileged pod, exit code: '%d'", exitCode)
@@ -101,12 +132,12 @@ func (p *PrivilegedPodSnifferService) Start(stdOut io.Writer) error {
 	log.Info("starting remote sniffing using privileged pod")
 
 	command := p.runtimeBridge.BuildTcpdumpCommand(
-		&p.settings.DetectedContainerId,
-		p.settings.UserSpecifiedInterface,
-		p.settings.UserSpecifiedFilter,
+		&p.DetectedContainerId,
+		p.UserSpecifiedInterface,
+		p.UserSpecifiedFilter,
 		p.targetProcessId,
-		p.settings.SocketPath,
-		p.settings.TCPDumpImage,
+		p.SocketPath,
+		p.TCPDumpImage,
 	)
 
 	exitCode, err := p.kubernetesApiService.ExecuteCommand(p.privilegedPod.Name, p.privilegedContainerName, command, stdOut)
@@ -118,4 +149,26 @@ func (p *PrivilegedPodSnifferService) Start(stdOut io.Writer) error {
 	log.Info("remote sniffing using privileged pod completed")
 
 	return nil
+}
+
+// Collect information about the container runtime that is running the Pod
+func getPodContainerRuntimeDetails(pod *corev1.Pod) (containerRuntime string, containerID string, err error) {
+	if len(pod.Spec.Containers) < 1 {
+		return "", "", fmt.Errorf("the pod provided does not have any containers")
+	}
+	containerName := pod.Spec.Containers[0].Name
+
+	for _, containerStatus := range pod.Status.ContainerStatuses {
+		if containerName == containerStatus.Name {
+			result := strings.Split(containerStatus.ContainerID, "://")
+			if len(result) != 2 {
+				break
+			}
+			containerRuntime = result[0]
+			containerID = result[1]
+			return
+		}
+	}
+	err = errors.Errorf("couldn't find container: '%s' in pod: '%s'", containerName, pod.Name)
+	return
 }

--- a/pkg/service/sniffer/static_tcpdump_sniffer_service.go
+++ b/pkg/service/sniffer/static_tcpdump_sniffer_service.go
@@ -10,20 +10,33 @@ import (
 )
 
 type StaticTcpdumpSnifferService struct {
-	settings             *config.KsniffSettings
+	*config.StaticTCPSnifferServiceConfig
 	kubernetesApiService kube.KubernetesApiService
 }
 
 func NewUploadTcpdumpRemoteSniffingService(options *config.KsniffSettings, service kube.KubernetesApiService) SnifferService {
-	return &StaticTcpdumpSnifferService{settings: options, kubernetesApiService: service}
+
+	
+	staticSniffer := &StaticTcpdumpSnifferService{
+		StaticTCPSnifferServiceConfig: &config.StaticTCPSnifferServiceConfig{
+			UserSpecifiedLocalTcpdumpPath: options.UserSpecifiedLocalTcpdumpPath, 
+			UserSpecifiedRemoteTcpdumpPath: options.UserSpecifiedRemoteTcpdumpPath ,
+			UserSpecifiedPodName:           options.UserSpecifiedPodName ,
+			UserSpecifiedContainer:         options.UserSpecifiedContainer ,
+			UserSpecifiedInterface:        options.UserSpecifiedInterface ,
+			UserSpecifiedFilter:            options.UserSpecifiedFilter ,
+		}, 
+		kubernetesApiService: service}
+	
+	return staticSniffer
 }
 
 func (u *StaticTcpdumpSnifferService) Setup() error {
 	log.Infof("uploading static tcpdump binary from: '%s' to: '%s'",
-		u.settings.UserSpecifiedLocalTcpdumpPath, u.settings.UserSpecifiedRemoteTcpdumpPath)
+		u.UserSpecifiedLocalTcpdumpPath, u.UserSpecifiedRemoteTcpdumpPath)
 
-	err := u.kubernetesApiService.UploadFile(u.settings.UserSpecifiedLocalTcpdumpPath,
-		u.settings.UserSpecifiedRemoteTcpdumpPath, u.settings.UserSpecifiedPodName, u.settings.UserSpecifiedContainer)
+	err := u.kubernetesApiService.UploadFile(u.UserSpecifiedLocalTcpdumpPath,
+		u.UserSpecifiedRemoteTcpdumpPath, u.UserSpecifiedPodName, u.UserSpecifiedContainer)
 
 	if err != nil {
 		log.WithError(err).Errorf("failed uploading static tcpdump binary to container, please verify the remote container has tar installed")
@@ -42,10 +55,10 @@ func (u *StaticTcpdumpSnifferService) Cleanup() error {
 func (u *StaticTcpdumpSnifferService) Start(stdOut io.Writer) error {
 	log.Info("start sniffing on remote container")
 
-	command := []string{u.settings.UserSpecifiedRemoteTcpdumpPath, "-i", u.settings.UserSpecifiedInterface,
-		"-U", "-w", "-", u.settings.UserSpecifiedFilter}
+	command := []string{u.UserSpecifiedRemoteTcpdumpPath, "-i", u.UserSpecifiedInterface,
+		"-U", "-w", "-", u.UserSpecifiedFilter}
 
-	exitCode, err := u.kubernetesApiService.ExecuteCommand(u.settings.UserSpecifiedPodName, u.settings.UserSpecifiedContainer, command, stdOut)
+	exitCode, err := u.kubernetesApiService.ExecuteCommand(u.UserSpecifiedPodName, u.UserSpecifiedContainer, command, stdOut)
 	if err != nil || exitCode != 0 {
 		return errors.Errorf("executing sniffer failed, exit code: '%d'", exitCode)
 	}


### PR DESCRIPTION
Sniffers should maintain their own state without fear of changes 'bleeding' out to any global state.

If side-affects come from instantiating a sniffer, this limits the ability to use the sniffers as reusable components. 
https://github.com/eldadru/ksniff/blob/e299ffb2ec044e21eae9f2d26a3eeb0d637fd617/pkg/service/sniffer/privileged_pod_sniffer_service.go#L31-L44

This PR copies the relevant configuration into the Sniffer internal state. I think there is more that can be done for this (renaming) but I wanted to be as un-invasive as possible.