### PR TITLE
Privileged container: IfNotPresent imagePullPolicy

### DIFF
--- a/kube/kubernetes_api_service.go
+++ b/kube/kubernetes_api_service.go
@@ -146,6 +146,7 @@ func (k *KubernetesApiServiceImpl) CreatePrivilegedPod(nodeName string, containe
 	privilegedContainer := corev1.Container{
 		Name:  containerName,
 		Image: image,
+		ImagePullPolicy: "IfNotPresent",
 
 		SecurityContext: &corev1.SecurityContext{
 			Privileged: &privileged,


### PR DESCRIPTION
This PR set the _ImagePullPolicy_ for the privileged container to `IfNotPresent` instead of the default `Always`.
This is handy in a no internet environment, when deploying images manually with `docker load` without having to setup/access a private Docker repo.
