### PR TITLE
Properly close Wireshark upon CTRL+C on Linux, Mac, and Windows.

### DIFF
--- a/pkg/cmd/sniff.go
+++ b/pkg/cmd/sniff.go
@@ -53,6 +53,7 @@ type Ksniff struct {
 	rawConfig        api.Config
 	settings         *config.KsniffSettings
 	snifferService   sniffer.SnifferService
+	wireshark        *exec.Cmd
 }
 
 func NewKsniff(settings *config.KsniffSettings) *Ksniff {
@@ -366,6 +367,19 @@ func (o *Ksniff) setupSignalHandler() chan interface{} {
 						log.WithError(err).Error("failed to teardown sniffer, a manual teardown is required.")
 					}
 					log.Info("sniffer cleanup completed successfully")
+
+					// Kill wireshark if used
+					if o.wireshark != nil {
+						if o.wireshark.Process != nil {
+							err = o.wireshark.Process.Kill()
+							if err != nil && err != os.ErrProcessDone {
+								log.WithError(err).Error("failed to kill wireshark process")
+							} else {
+								log.Debug("wireshark process killed")
+							}
+						}
+					}
+
 					close(signals)
 				}
 			case <-exit:
@@ -418,9 +432,9 @@ func (o *Ksniff) Run() error {
 		log.Info("spawning wireshark!")
 
 		title := fmt.Sprintf("gui.window_title:%s/%s/%s", o.resultingContext.Namespace, o.settings.UserSpecifiedPodName, o.settings.UserSpecifiedContainer)
-		cmd := exec.Command("wireshark", "-k", "-i", "-", "-o", title)
+		o.wireshark = exec.Command("wireshark", "-k", "-i", "-", "-o", title)
 
-		stdinWriter, err := cmd.StdinPipe()
+		stdinWriter, err := o.wireshark.StdinPipe()
 		if err != nil {
 			return err
 		}
@@ -429,14 +443,12 @@ func (o *Ksniff) Run() error {
 			err := o.snifferService.Start(stdinWriter)
 			if err != nil {
 				log.WithError(err).Errorf("failed to start remote sniffing, stopping wireshark")
-				_ = cmd.Process.Kill()
+				_ = o.wireshark.Process.Kill()
 			}
 		}()
 
-		err = cmd.Run()
-		if err != nil {
-			return err
-		}
+		err = o.wireshark.Run()
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
The PR contains what I think is the simplest solution to cross-platform handling of CTRL+C. 