### PR TITLE
Add devcontainer and Linux arm64 support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,8 @@
+FROM mcr.microsoft.com/vscode/devcontainers/base:debian
+
+# Install kubectl.
+ARG KUBECTL_VERSION=v1.25.0
+RUN curl -SOL \
+  https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/$(dpkg --print-architecture)/kubectl \
+  && install kubectl /usr/local/bin \
+  && rm kubectl

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,18 @@
+{
+	"name": "Debian",
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
+	"remoteUser": "vscode",
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"golang.go",
+				"ms-kubernetes-tools.vscode-kubernetes-tools"
+			]
+		}
+	},
+	"features": {
+		"golang": "latest"
+	}
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,35 @@
+# File created using '.gitignore Generator' for Visual Studio Code: https://bit.ly/vscode-gig
+# Created by https://www.toptal.com/developers/gitignore/api/go
+# Edit at https://www.toptal.com/developers/gitignore?templates=go
+
+### Go ###
+# If you prefer the allow list template instead of the deny list, see community template:
+# https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
+#
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# Go workspace file
+go.work
+
+### Go Patch ###
+/vendor/
+/Godeps/
+
+# End of https://www.toptal.com/developers/gitignore/api/go
+
+# Custom rules (everything added below won't be overriden by 'Generate .gitignore File' if you use 'Update' option)
+kubectl-sniff*

--- a/.krew.yaml
+++ b/.krew.yaml
@@ -6,58 +6,53 @@ spec:
   version: {{ .TagName }}
   homepage: https://github.com/eldadru/ksniff
   platforms:
-  - {{ addURIAndSha "https://github.com/eldadru/ksniff/releases/download/{{ .TagName }}/ksniff.zip" .TagName }}
-    bin: kubectl-sniff
-    files:
-    - from: kubectl-sniff-darwin
-      to: kubectl-sniff
-    - from: static-tcpdump
-      to: .
-    - from: LICENSE
-      to: .
-    selector:
-      matchLabels:
-        os: darwin
-        arch: amd64
-  - {{ addURIAndSha "https://github.com/eldadru/ksniff/releases/download/{{ .TagName }}/ksniff.zip" .TagName }}
-    bin: kubectl-sniff
-    files:
-    - from: kubectl-sniff-darwin-arm64
-      to: kubectl-sniff
-    - from: static-tcpdump
-      to: .
-    - from: LICENSE
-      to: .
-    selector:
-      matchLabels:
-        os: darwin
-        arch: arm64
-  - {{ addURIAndSha "https://github.com/eldadru/ksniff/releases/download/{{ .TagName }}/ksniff.zip" .TagName }}
-    bin: kubectl-sniff
-    files:
-    - from: kubectl-sniff
-      to: .
-    - from: static-tcpdump
-      to: .
-    - from: LICENSE
-      to: .
-    selector:
-      matchLabels:
-        os: linux
-        arch: amd64
-  - {{ addURIAndSha "https://github.com/eldadru/ksniff/releases/download/{{ .TagName }}/ksniff.zip" .TagName }}
-    bin: kubectl-sniff.exe
-    files:
-    - from: kubectl-sniff-windows
-      to: kubectl-sniff.exe
-    - from: static-tcpdump
-      to: .
-    - from: LICENSE
-      to: .
-    selector:
-      matchLabels:
-        os: windows
-        arch: amd64
+    - &platform-config
+      bin: kubectl-sniff
+      {{ addURIAndSha "https://github.com/eldadru/ksniff/releases/download/{{ .TagName }}/ksniff.zip" .TagName }}
+      files:
+        - from: kubectl-sniff-darwin
+          to: kubectl-sniff
+        - from: static-tcpdump
+          to: .
+        - from: LICENSE
+          to: .
+      selector:
+        matchLabels:
+          os: darwin
+          arch: amd64
+    - << : *platform-config
+      files:
+        - from: kubectl-sniff-darwin-arm64
+          to: kubectl-sniff
+      selector:
+        matchLabels:
+          os: darwin
+          arch: arm64
+    - << : *platform-config
+      files:
+        - from: kubectl-sniff
+          to: kubectl-sniff
+      selector:
+        matchLabels:
+          os: linux
+          arch: amd64
+    - << : *platform-config
+      files:
+        - from: kubectl-sniff-arm64
+          to: kubectl-sniff
+      selector:
+        matchLabels:
+          os: linux
+          arch: arm64
+    - << : *platform-config
+      bin: kubectl-sniff.exe
+      files:
+        - from: kubectl-sniff-windows
+          to: kubectl-sniff.exe
+      selector:
+        matchLabels:
+          os: windows
+          arch: amd64
   shortDescription: Start a remote packet capture on pods using tcpdump and wireshark
   caveats: |
     This plugin needs the following programs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,7 @@ deploy:
       tags: true
       branch: master
   - provider: script
-    script:
-      - env GITHUB_TOKEN=${GITHUB_OAUTH_TOKEN} bash scripts/update-krew-index.sh
+    script: env GITHUB_TOKEN=${GITHUB_OAUTH_TOKEN} bash scripts/update-krew-index.sh
     on:
       tags: true
       branch: master

--- a/Makefile
+++ b/Makefile
@@ -21,11 +21,16 @@ endif
 endif
 
 ifeq ($(UNAME), Linux)
+ifeq ($(ARCH_NAME), arm64)
+PLUGIN_NAME=kubectl-sniff-arm64
+else
 PLUGIN_NAME=kubectl-sniff
+endif
 endif
 
 linux:
 	GO111MODULE=on GOOS=linux GOARCH=amd64 go build -o kubectl-sniff cmd/kubectl-sniff.go
+	GO111MODULE=on GOOS=linux GOARCH=arm64 go build -o kubectl-sniff-arm64 cmd/kubectl-sniff.go
 
 windows:
 	GO111MODULE=on GOOS=windows GOARCH=amd64 go build -o kubectl-sniff-windows cmd/kubectl-sniff.go
@@ -47,7 +52,7 @@ static-tcpdump:
 	rm -rf tcpdump-${TCPDUMP_VERSION} tcpdump-${TCPDUMP_VERSION}.tar.gz
 
 package:
-	zip ksniff.zip kubectl-sniff kubectl-sniff-windows kubectl-sniff-darwin kubectl-sniff-darwin-arm64 static-tcpdump Makefile plugin.yaml LICENSE
+	zip ksniff.zip kubectl-sniff kubectl-sniff-arm64 kubectl-sniff-windows kubectl-sniff-darwin kubectl-sniff-darwin-arm64 static-tcpdump Makefile plugin.yaml LICENSE
 
 install:
 	mkdir -p ${PLUGIN_FOLDER}
@@ -65,9 +70,9 @@ verify_version:
 
 clean:
 	rm -f kubectl-sniff
+	rm -f kubectl-sniff-arm64
 	rm -f kubectl-sniff-windows
 	rm -f kubectl-sniff-darwin
 	rm -f kubectl-sniff-darwin-arm64
 	rm -f static-tcpdump
 	rm -f ksniff.zip
-


### PR DESCRIPTION
- Add a basic devcontainer configuration which allows this package to be built from a Docker image with all dependencies integrated.
- Add a `.gitignore` to prevent built binaries from being picked up as new files.
- Use YAML anchors to simplify the `.krew.yaml` configuration.
- Add Linux ARM64 support.
- Fix syntax error in `.travis.yml`.