### PR TITLE
Add --request-timeout CLI flag to customize k8s api client timeout

### DIFF
--- a/pkg/config/settings.go
+++ b/pkg/config/settings.go
@@ -11,6 +11,7 @@ type KsniffSettings struct {
 	UserSpecifiedInterface         string
 	UserSpecifiedFilter            string
 	UserSpecifiedPodCreateTimeout  time.Duration
+	UserSpecifiedRequestTimeout    time.Duration
 	UserSpecifiedContainer         string
 	UserSpecifiedNamespace         string
 	UserSpecifiedOutputFile        string


### PR DESCRIPTION
These changes fix the https://github.com/eldadru/ksniff/issues/179 issue by adding `--request-timeout` CLI flag

Example of usage ksnif after merging these changes:
```
kubectl sniff --request-timeout 520s --pod-creation-timeout 520s -p -n default nginx-69f9fb6f84
```