### PR TITLE
Pull tcpdump image with ctr instead of crictl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/kubectl-sniff
+/kubectl-sniff-darwin
+/kubectl-sniff-darwin-arm64
+/kubectl-sniff-windows

--- a/pkg/service/sniffer/runtime/containerd.go
+++ b/pkg/service/sniffer/runtime/containerd.go
@@ -7,7 +7,7 @@ import (
 
 type ContainerdBridge struct {
 	tcpdumpContainerName string
-	socketPath string
+	socketPath           string
 }
 
 func NewContainerdBridge() *ContainerdBridge {
@@ -63,7 +63,7 @@ func (d *ContainerdBridge) BuildCleanupCommand() []string {
 }
 
 func (d ContainerdBridge) GetDefaultImage() string {
-	return "docker.io/hamravesh/ksniff-helper:v3"
+	return "docker.io/gregoirew/ksniff-helper:release"
 }
 
 func (d *ContainerdBridge) GetDefaultTCPImage() string {


### PR DESCRIPTION
This fix #183  (ctr doesn't find the image pull by crictl)

I did test against my existing GKE cluster, nothing more.